### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cargo-validate"
 version = "0.2.0"
 edition = "2021"
 license = "MIT"
-repository = "http://github.com/themackabu/cargo-validate"
+repository = "https://github.com/themackabu/cargo-validate"
 
 description = "verify everything is correct about your package before publishing"
 categories = ["development-tools::cargo-plugins"]


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97